### PR TITLE
fix: setting circle progress bar initial state to zero

### DIFF
--- a/Sources/Indicators/CircleView.swift
+++ b/Sources/Indicators/CircleView.swift
@@ -20,7 +20,7 @@ struct CircleView: View {
             ZStack(alignment: .leading) {
                 Arc(startAngle: .radians(-.pi / 2), endAngle: .radians(.pi * 3 / 2))
                     .stroke(backgroundColor, style: .init(lineWidth: lineWidth, lineCap: .butt, lineJoin: .miter))
-                Arc(startAngle: .radians(-.pi / 2), endAngle: .radians(.pi * 3 / 2 * progress))
+                Arc(startAngle: .radians(-.pi / 2), endAngle: .radians(-.pi / 2 + .pi * 3 / 2 * progress))
                     .stroke(strokeColor, style: .init(lineWidth: lineWidth, lineCap: .butt, lineJoin: .miter))
                     .animation(.easeIn, value: progress)
             }


### PR DESCRIPTION
### Issue
1. Circle progress view starts at 90 deg for progress value 0 #9 

### Fix
Making start point and end point consistent by adding -.pi/2 to end point.

